### PR TITLE
Header designs with focus on Mobile

### DIFF
--- a/assets/css/woocommerce.css
+++ b/assets/css/woocommerce.css
@@ -53,6 +53,7 @@
  .wc-block-product-on-sale .wc-block-grid__product-add-to-cart a{
     width:100%!important;
 }
+
  .tab-included-products.chained_items_container li{
     font-size: var(--wp--preset--font-size--x-small) !important;
     line-height: 20px;
@@ -614,6 +615,25 @@
 .editor-styles-wrapper table.wc-block-cart-items .wc-block-cart-items__row .wc-block-cart-item__quantity .wc-block-cart-item__remove-link, table.wc-block-cart-items .wc-block-cart-items__row .wc-block-cart-item__quantity .wc-block-cart-item__remove-link{
     color:#FF0000!important;
 }
+.woocommerce .woocommerce-info .button{
+    background-color: var(--wp--preset--color--secondary);
+    border-radius: 0;
+    border-width: 0;
+    color: var(--wp--preset--color--base);
+    font-family: inherit;
+    font-size: var(--wp--preset--font-size--x-small);
+    font-weight: 700;
+    line-height: inherit;
+    margin-top: 0px;
+    margin-right: 0px;
+    margin-bottom: 0px;
+    margin-left: 0px;
+    padding-top: 10px;
+    padding-right: 20px;
+    padding-bottom: 10px;
+    padding-left: 20px;
+    text-decoration: none;
+}
 
 /* Bundles ---------------------------------------------------------------------------- */
  .bundle_sells_title h3{
@@ -729,4 +749,8 @@
         font-size:36px;
         text-align: center;
     }
+    .woocommerce-cart-form__contents .cart_item.chained_item{display:none!important;}
+
+    .woocommerce .woocommerce-info .button{width:100%!important;}
+
 }

--- a/includes/patterns/header/header-default.php
+++ b/includes/patterns/header/header-default.php
@@ -17,5 +17,8 @@ return array(
 	
 	<!-- wp:navigation {"layout":{"type":"flex","orientation":"horizontal"},"style":{"spacing":{"blockGap":"20px"}}} /--></div>
 	<!-- /wp:group --></div>
-	<!-- /wp:group -->',
+	<!-- /wp:group -->
+	
+	
+	',
 );

--- a/parts/header-cta.html
+++ b/parts/header-cta.html
@@ -1,0 +1,14 @@
+<!-- wp:group {"className":"header-cta has-base-background-color has-background"} -->
+<div class="wp-block-group header-cta has-base-background-color has-background"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"20px","bottom":"10px"},"margin":{"top":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"backgroundColor":"base","textColor":"contrast","layout":{"type":"constrained"}} -->
+    <div class="wp-block-group alignfull has-contrast-color has-base-background-color has-text-color has-background has-link-color" style="margin-top:0px;padding-top:20px;padding-bottom:10px"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"0","padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"className":"cta-row","layout":{"type":"flex","justifyContent":"space-between"}} -->
+    <div class="wp-block-group alignwide cta-row" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:site-logo {"width":100} /-->
+    
+  <!-- wp:navigation {"icon":"menu","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"1.25rem"},"typography":{"lineHeight":"1"}}} /-->    
+    <!-- wp:buttons {"className":"cta"} -->
+    <div class="wp-block-buttons cta"><!-- wp:button -->
+    <div class="wp-block-button"><a class="wp-block-button__link wp-element-button">CTA Button</a></div>
+    <!-- /wp:button --></div>
+    <!-- /wp:buttons --></div>
+    <!-- /wp:group --></div>
+    <!-- /wp:group --></div>
+    <!-- /wp:group -->

--- a/parts/header-dark.html
+++ b/parts/header-dark.html
@@ -1,10 +1,9 @@
-<!-- wp:group {"style":"backgroundColor":"base","layout":{"type":"constrained"}} -->
-<div class="wp-block-group has-base-background-color has-background">
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"20px","bottom":"10px"},"margin":{"top":"0px"}}},"backgroundColor":"contrast","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-contrast-background-color has-background" style="margin-top:0px;padding-top:20px;padding-bottom:10px"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"0","padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:site-logo {"width":100} /-->
-<!-- wp:navigation {"textColor":"base","layout":{"type":"flex","orientation":"horizontal"},"style":{"spacing":{"blockGap":"var:preset|spacing|x-small"}}} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-</div>
-<!-- /wp:group -->
+<!-- wp:group {"className":"header-default has-base-background-color has-background"} -->
+<div class="wp-block-group header-default has-base-background-color has-background"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"20px","bottom":"10px"},"margin":{"top":"0px"}}},"backgroundColor":"contrast","layout":{"type":"constrained"}} -->
+    <div class="wp-block-group alignfull has-contrast-background-color has-background" style="margin-top:0px;padding-top:20px;padding-bottom:10px"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"0","padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
+    <div class="wp-block-group alignwide" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:site-logo {"width":100} /-->
+    
+    <!-- wp:navigation {"textColor":"base","overlayBackgroundColor":"contrast","overlayTextColor":"base","layout":{"type":"flex","orientation":"horizontal"},"style":{"spacing":{"blockGap":"var:preset|spacing|x-small"}}} /--></div>
+    <!-- /wp:group --></div>
+    <!-- /wp:group --></div>
+    <!-- /wp:group -->

--- a/parts/header.html
+++ b/parts/header.html
@@ -1,15 +1,11 @@
-<!-- wp:group {"style":"backgroundColor":"base","layout":{"type":"constrained"}} -->
-<div class="wp-block-group has-base-background-color has-background">
-<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|x-small","right":"0","bottom":"var:preset|spacing|x-small","left":"0"},"blockGap":"0"}},"layout":{"inherit":true,"type":"constrained"}} -->
-<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--x-small);padding-right:0;padding-bottom:var(--wp--preset--spacing--x-small);padding-left:0"><!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
-    <div class="wp-block-group alignwide" style="margin-top:0;margin-bottom:0"><!-- wp:group {"layout":{"type":"flex"}} -->
-    <div class="wp-block-group"><!-- wp:site-logo {"width":120} /-->
-    </div>
-    <!-- /wp:group -->
-    
-  <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"1.25rem"},"typography":{"lineHeight":"1"}}} /-->
-</div>
-    <!-- /wp:group --></div>
-    <!-- /wp:group -->
-</div>
-<!-- /wp:group -->
+<!-- wp:group {"style":{"position":{"type":""}},"className":"header-default has-base-background-color has-background"} -->
+<div class="wp-block-group header-default has-base-background-color has-background"><!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|x-small","right":"0","bottom":"var:preset|spacing|x-small","left":"0"},"blockGap":"0"}},"layout":{"inherit":true,"type":"constrained"}} -->
+  <div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--x-small);padding-right:0;padding-bottom:var(--wp--preset--spacing--x-small);padding-left:0"><!-- wp:group {"align":"wide","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
+  <div class="wp-block-group alignwide" style="margin-top:0;margin-bottom:0"><!-- wp:group {"layout":{"type":"flex"}} -->
+  <div class="wp-block-group"><!-- wp:site-logo /--></div>
+  <!-- /wp:group -->
+  
+  <!-- wp:navigation {"icon":"menu","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"1.25rem"},"typography":{"lineHeight":"1"}}} /--></div>
+  <!-- /wp:group --></div>
+  <!-- /wp:group --></div>
+  <!-- /wp:group -->

--- a/parts/woo-header-dark.html
+++ b/parts/woo-header-dark.html
@@ -1,14 +1,14 @@
-<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"backgroundColor":"contrast","textColor":"base","layout":{"type":"constrained"}} -->
-<div class="wp-block-group has-base-color has-contrast-background-color has-text-color has-background has-link-color"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"margin":{"top":"0","bottom":"0"},"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"backgroundColor":"contrast","textColor":"base","className":"woo-default","layout":{"type":"constrained"}} -->
+<div class="wp-block-group woo-default has-base-color has-contrast-background-color has-text-color has-background has-link-color"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"margin":{"top":"0","bottom":"0"},"blockGap":"0"}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group alignwide" style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|x-small","top":"var:preset|spacing|x-small"}}},"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
     <div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--x-small);padding-bottom:var(--wp--preset--spacing--x-small)"><!-- wp:group {"layout":{"type":"flex"}} -->
     <div class="wp-block-group"><!-- wp:site-logo {"width":169} /--></div>
     <!-- /wp:group -->
     
-    <!-- wp:navigation {"textColor":"base","icon":"menu","overlayBackgroundColor":"contrast","overlayTextColor":"base","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"},"style":{"spacing":{"blockGap":"var:preset|spacing|x-small"},"typography":{"fontSize":"18px"}}} /-->
+    <!-- wp:navigation {"textColor":"base","backgroundColor":"contrast","icon":"menu","overlayBackgroundColor":"contrast","overlayTextColor":"base","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"1.25rem"},"typography":{"lineHeight":"1"}}} /-->
     
     <!-- wp:group {"className":"minicart","layout":{"type":"flex","flexWrap":"nowrap"}} -->
-    <div class="wp-block-group minicart"><!-- wp:woocommerce/mini-cart {"addToCartBehaviour":"open_drawer","fontFamily":"primary","fontSize":"small"} /-->
+    <div class="wp-block-group minicart"><!-- wp:woocommerce/mini-cart {"addToCartBehaviour":"open_drawer","hasHiddenPrice":true,"fontSize":"small"} /-->
     
     <!-- wp:woocommerce/customer-account {"displayStyle":"icon_only","iconClass":"wc-block-customer-account__account-icon","fontSize":"small"} /--></div>
     <!-- /wp:group --></div>

--- a/parts/woo-header-light.html
+++ b/parts/woo-header-light.html
@@ -1,14 +1,14 @@
-<!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"margin":{"top":"0","bottom":"0"},"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"className":"woo-default","layout":{"type":"constrained"}} -->
+<div class="wp-block-group woo-default"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"margin":{"top":"0","bottom":"0"},"blockGap":"0"}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group alignwide" style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|x-small","top":"var:preset|spacing|x-small"}}},"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
     <div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--x-small);padding-bottom:var(--wp--preset--spacing--x-small)"><!-- wp:group {"layout":{"type":"flex"}} -->
     <div class="wp-block-group"><!-- wp:site-logo {"width":169} /--></div>
     <!-- /wp:group -->
     
-    <!-- wp:navigation {"textColor":"contrast","icon":"menu","overlayBackgroundColor":"base","overlayTextColor":"contrast","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"},"style":{"spacing":{"blockGap":"var:preset|spacing|x-small"},"typography":{"fontSize":"18px"}}} /-->
+    <!-- wp:navigation {"ref":1832,"icon":"menu","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"1.25rem"},"typography":{"lineHeight":"1"}}} /-->
     
     <!-- wp:group {"className":"minicart","layout":{"type":"flex","flexWrap":"nowrap"}} -->
-    <div class="wp-block-group minicart"><!-- wp:woocommerce/mini-cart {"addToCartBehaviour":"open_drawer","fontFamily":"primary","fontSize":"small"} /-->
+    <div class="wp-block-group minicart"><!-- wp:woocommerce/mini-cart {"addToCartBehaviour":"open_drawer","hasHiddenPrice":true,"fontSize":"small"} /-->
     
     <!-- wp:woocommerce/customer-account {"displayStyle":"icon_only","iconClass":"wc-block-customer-account__account-icon","fontSize":"small"} /--></div>
     <!-- /wp:group --></div>

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@ Theme URI: 			https://lsx.design/
 Description: 		LSX Design is a light-weight WordPress Block Theme designed to empower makers to build beautifully rich websites using WordPress Block Editor and Site Editor. We take full advantage of the block editor, which gives you more control over creating your content. Install the free Blocks plugin to add additional blocks and extend core WordPress blocks. Users can easily install any of the 20 free extensions via the WordPress plugins page. The flexibility is perfect for blogs, small business, startups, agencies, firms, WooCommerce stores and portfolio sites. LSX Design is fully compatibility with WooCommerce & WooCommerce Blocks, making it an ideal choice for your next eCommerce build.
 Author: 			LightSpeed 
 Author URI: 		https://www.lsdev.biz/ 
-Version: 			1.1.0
+Version: 			1.2.0
 Tested up to: 		6.3
 Requires at least: 	6.0
 Requires PHP: 		7.4
@@ -53,7 +53,7 @@ body .is-layout-constrained > .wp-block-group.alignfull {
      font-weight: var(--wp--custom--font-weight--medium);
 }
 p.has-base-color a, .has-base-color.has-link-color a{
-    color: var(--wp--preset--color--base) !important;text-decoration: none!important;font-weight:bold!important;
+    color: var(--wp--preset--color--base) !important;text-decoration: none!important;
 }
 .has-base-color.has-link-color a:hover{color: var(--wp--preset--color--base) !important;text-decoration: underline!important;}
  blockquote {
@@ -64,14 +64,6 @@ p.has-base-color a, .has-base-color.has-link-color a{
     color: currentColor!important;
 }
 
-/* Header --------------------------------------------- */
-@media (max-width: 1250px) {
-	header :where(.has-global-padding),
-	footer :where(.has-global-padding) {
-		padding-left: var(--wp--preset--spacing--x-small) !important;
-		padding-right: var(--wp--preset--spacing--x-small) !important;
-	}
-}
 
 /* Quote --------------------------------------------- */
  .wp-block-quote.is-style-underline, .wp-block-quote.is-style-underline-primary-secondary, .wp-block-quote.is-style-underline-secondary-tertiary, .wp-block-quote.is-style-underline-tertiary-primary {
@@ -211,13 +203,6 @@ body .wp-block-navigation .wp-block-navigation-item__description {
 	flex-direction: column;
 }
 
-@media (min-width: 600px) {
-	.wp-block-navigation .wp-block-navigation-item a:hover,
-	.wp-block-navigation .wp-block-navigation__container > .wp-block-navigation-item > .current-menu-item,
-	.wp-block-navigation .wp-block-navigation__container > .wp-block-navigation-item.current-menu-item > a {
-		color: var(--wp--preset--color--cta);
-	}
-}
 
 
 /* Navigation Submenu --------------------------------------------- */
@@ -443,6 +428,43 @@ body .wp-block-navigation .wp-block-navigation-item__description {
  footer .has-contrast-background-color .wp-block-social-links:not(.is-style-logos-only) footer .has-contrast-background-color .wp-block-social-links .wp-social-link a{
     color:#000!important;
 }
+.login #wfls-prompt-overlay input[type="text"]{
+    font-size: var(--wp--preset--font-size--small);
+    padding: 0.9rem 1.1rem;
+    border: 2px solid #2B2D2F!important;
+    box-sizing: border-box;
+    width: 100%;
+    margin: 0;
+    outline: 0;
+    line-height: normal;
+}
+.login #wfls-prompt-overlay input[type="submit"]{
+background-color: var(--wp--preset--color--secondary);
+    border-radius: 0;
+    border-width: 0;
+    color: var(--wp--preset--color--base);
+    font-family: inherit;
+    font-size: var(--wp--preset--font-size--small);
+    font-weight: 700;
+    line-height: inherit;
+    margin-top: 0px;
+    margin-right: 0px;
+    margin-bottom: 0px;
+    margin-left: 0px;
+    padding-top: 10px;
+    padding-right: 20px;
+    padding-bottom: 10px;
+    padding-left: 20px;
+    text-decoration: none;
+}
+.wp-block-navigation__responsive-container-close svg, .wp-block-navigation__responsive-container-open svg {
+    fill: currentColor;
+    display: block;
+    height: 48px;
+    pointer-events: none;
+    width: 48px;
+}
+.mobile-search, .header-default .wp-block-search, .header-cta .wp-block-search{display:none;}
 @media screen and (max-width:1028px) {
     .wp-block-navigation__responsive-container-open:not(.always-shown){
         display: block;
@@ -453,33 +475,101 @@ body .wp-block-navigation .wp-block-navigation-item__description {
 }
 /* Media Queries ---------------------------------------------------------------------------- */
  @media (max-width:599px) {
+    .mobile-search, .header-default .wp-block-search, .header-cta .wp-block-search{
+        display:block!important;
+    }
+    .wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__responsive-container-content .wp-block-navigation__container, .wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__responsive-container-content .wp-block-navigation__submenu-container{gap:0!important;}
+    .site-header .has-contrast-background-color .wp-block-navigation__responsive-container-content .wp-block-search{
+        background-color: #000;
+        border:1px solid #fff;
+        padding: 0px;
+        width:100%; margin:0!important;
+        color: #fff!important;
+    }
+    .woo-default .wp-block-search__button, .woo-default .wp-block-search__button.has-icon,.woo-default .wp-block-search__inside-wrapper input{color:#000!important;}
+    .site-header .has-base-background-color .wp-block-search__button, .has-base-background-color .wp-block-search__button.has-icon{color:#000!important;}
+    .site-header .has-contrast-background-color .wp-block-search__button, .has-contrast-background-color .wp-block-search__button.has-icon{color:#fff!important;}
+
+    .site-header .wp-block-navigation__responsive-container-content .wp-block-search{
+        background-color: #fff;
+        border:1px solid #000;
+        padding: 0px;
+        width:100%; margin:0!important;
+        color: #000!important;
+    }
+    .site-header .wp-block-navigation__responsive-container-content{
+        padding-top:60px!important;
+    }
+    .header-cta .cta {
+        width: 100%;
+    display: block;
+    top: 8px;
+    position: absolute;
+    background: #fff;
+    padding: 10px;
+    left: 10px;
+    }
+    .has-modal-open .header-cta .cta {
+        width: 96%;
+        display: block;
+        bottom:0px!important;
+        top:auto!important;
+        position: absolute;
+        z-index:999999!important;
+    }
+    .woo-default{padding:0 0px 0 10px!important;}
+    .woo-default .wp-block-group{gap:0!important;}
+    .woo-default .wp-block-navigation{order: 3;}
+    .woo-default .minicart{order: 2;}
+    .wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation-item, .wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation-item .wp-block-navigation__submenu-container, .wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__container, .wp-block-navigation__responsive-container.is-menu-open .wp-block-page-list{background: inherit!important;}
+    .has-modal-open .header-cta .wp-block-navigation:not(.has-background) .wp-block-navigation__responsive-container.is-menu-open{max-height:92%;}
+    .header-cta .cta a {
+        width:96%;
+    }
+    .header-cta .cta .wp-block-button{
+        width:100%;margin:0!important;
+    }
+    .header-cta .cta-row{
+        margin-top:38px;
+    }
+    .wp-block-navigation__responsive-container.is-menu-open{
+        padding-right:0!important;
+        padding-left:0!important;
+    }
+
+   /* .has-modal-open header .wp-block-image.logo, .has-modal-open header .wp-block-site-logo {
+        z-index: 99999999;}
+        */
+
+        .has-modal-open header .header-cta .wp-block-site-logo{margin-top:-80px!important;}
+
+        .wp-block-navigation .wp-block-navigation-item{width:100%;}
+        .wp-block-navigation__submenu-container{width:100%; background: #EEEEEE!important;}
+        .wp-block-navigation__submenu-container li{width:100%; background: #EEEEEE!important;}
     /* Navigation Link --------------------------------------------- */
 
-    .has-global-padding :where(.has-global-padding){padding: 0 var(--wp--preset--spacing--x-small) !important;}
+    .wp-block-navigation .wp-block-navigation-item{
+        padding: 12px 0px;}
+    .site-header .wp-block-group.alignwide.is-layout-flex, .site-header .wp-block-group.alignfull.is-layout-flex{
+        display: flex;
+        flex-wrap: nowrap;
+    }
+    .wp-block-navigation__responsive-container.has-contrast-color .wp-block-navigation-submenu .wp-block-navigation__submenu-icon svg{stroke:#000!important;}
+    .has-base-color .wp-block-navigation-submenu .wp-block-navigation__submenu-icon svg{color:#fff!important;}
     .wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__container{
-        padding:10px 0 0 var(--wp--preset--spacing--x-small);}
-
-  .entry-content .wp-block-group.has-global-padding{padding-right: 10px!important;padding-left:10px!important;}
+        padding:10px 0 0 var(--wp--preset--spacing--x-small);
+    }
      .wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__container{
         padding:10px 0 0 15px;
     }
     .wp-block-buttons>.wp-block-button.wp-block-button__width-50, .wp-block-buttons>.wp-block-button.wp-block-button__width-25{width:100%!important;}
 
-    header .minicart{
-        z-index: 99999999;
-        margin-right:50px;
-    }
-    .wp-block-navigation{
-        right: 20px;
-        position: absolute;
-    }
     .wp-block-navigation__responsive-container.is-menu-open .wp-block-search .wp-block-search__inside-wrapper input::placeholder {
         color:#fff!important;
         padding-left:15px;
     }
     .wp-block-navigation__responsive-container-close {
          right: 20px;
-         top: -46px;
     }
     .desktopnone{
         display:block;
@@ -488,7 +578,7 @@ body .wp-block-navigation .wp-block-navigation-item__description {
         display:none!important;
     }
     .wp-block-navigation__responsive-container.is-menu-open{
-        padding-top: var(--wp--preset--spacing--x-large);
+        padding-top: 16px;
     }
 
 	.wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__responsive-container-content .has-child .wp-block-navigation__submenu-container {
@@ -504,9 +594,6 @@ body .wp-block-navigation .wp-block-navigation-item__description {
         border-radius: 0;
     }
     
-	header .wp-block-image.logo, header .wp-block-site-logo{
-        z-index: 99999999;
-    }
     .wp-block-navigation__responsive-container.is-menu-open .wp-block-search__button{
         background:none!important;
         padding-right:0;
@@ -521,8 +608,8 @@ body .wp-block-navigation .wp-block-navigation-item__description {
     .wp-block-navigation__responsive-container.is-menu-open .wp-block-navigation__responsive-container-content{
 		align-items: inherit!important;
 		padding-top:var(--wp--preset--spacing--x-small);
-		padding-left:var(--wp--preset--spacing--x-small);
-		padding-right:var(--wp--preset--spacing--x-small);
+		padding-left:0;
+		padding-right:0;
 	}
 }
 @media (max-width:960px){ .wp-block-navigation .wp-block-navigation__submenu-icon{

--- a/theme.json
+++ b/theme.json
@@ -992,6 +992,11 @@
 		},
 		{
 			"area": "header",
+			"name": "header-cta",
+			"title": "Header CTA"
+		},
+		{
+			"area": "header",
 			"name": "woo-header-light",
 			"title": "Woo Header Light"
 		},


### PR DESCRIPTION

### LSX Header Design improvements for Mobile


### Changes made to the following template parts

**Wordpress:** 
- Standard
- CTA Header
- Dark

**WooCommerce:** 
- Woo Default Light
- Woo Default Dark

### Benefits

Improved Mobile experience and clean designs based on template preference. 

### Pre-submit checklist
As the author of this pull request, I verify that: 

### Testing
**How to test the changes in this pull request**

Follow the steps below to test the changes in this PR.

- Deploy this branch to the dev environment.
- Navigate to the Site Editor and select the index template. 
- Navigate to the Header settings > Change header. 
- Enable the new header template part. Save. 
Navigate to the homepage and view on Mobile screen size. 

### Changelog Entry
- style.css
- parts/header.html
- parts/header-cta.html
- parts/header-dark.html
- parts/woo-header-dark.html
- parts/woo-header-light.html
- theme.json