### PR TITLE
Remove of the "theme" attribute

### DIFF
--- a/templates/archive.html
+++ b/templates/archive.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"lsx-design","tagName":"header","align":"wide","className":"site-header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","align":"wide","className":"site-header"} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","right":"0","left":"0"}}},"layout":{"type":"constrained","contentSize":"1200px"}} -->
 <div class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
@@ -40,4 +40,4 @@
 	<!-- /wp:query --></div>
 	<!-- /wp:group -->
 	
-	<!-- wp:template-part {"slug":"footer","theme":"lsx-design","tagName":"footer","className":"site-footer"} /-->
+	<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"lsx-design","tagName":"header","align":"wide","className":"site-header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","align":"wide","className":"site-header"} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","right":"0","left":"0"}}},"layout":{"type":"constrained","contentSize":"1200px","justifyContent":"center"}} -->
 <div class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:columns {"verticalAlignment":"center","align":"wide","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
@@ -44,4 +44,4 @@
 	<!-- /wp:query --></div>
 	<!-- /wp:group -->
 	
-<!-- wp:template-part {"slug":"footer","theme":"lsx-design","tagName":"footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/no-title.html
+++ b/templates/no-title.html
@@ -1,7 +1,7 @@
-<!-- wp:template-part {"slug":"header","theme":"lsx-design","tagName":"header","align":"wide","className":"site-header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","align":"wide","className":"site-header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0"}}},"className":"site-content"} -->
 <main class="wp-block-group site-content" style="margin-top:0"><!-- wp:post-content {"layout":{"type":"constrained"}} /--></main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"lsx-design","tagName":"footer","className":"site-footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"lsx-design","tagName":"header","align":"wide","className":"site-header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","align":"wide","className":"site-header"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0"},"padding":{"top":"40px","bottom":"80px"}}},"className":"site-content"} -->
 <main class="wp-block-group site-content" style="margin-top:0;padding-top:40px;padding-bottom:80px"><!-- wp:group {"layout":{"type":"constrained"}} -->
@@ -8,4 +8,4 @@
 <!-- wp:post-content {"layout":{"type":"constrained"}} /--></main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"lsx-design","tagName":"footer","className":"site-footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"lsx-design","tagName":"header","align":"wide","className":"site-header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","align":"wide","className":"site-header"} /-->
 
 <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"0","bottom":"var:preset|spacing|small"}}},"layout":{"type":"constrained","contentSize":"1200px"}} -->
 <div class="wp-block-group alignwide" style="padding-top:0;padding-bottom:var(--wp--preset--spacing--small)"><!-- wp:group {"align":"wide","layout":{"type":"default"}} -->
@@ -49,7 +49,7 @@
     <!-- /wp:group -->
     
     <!-- wp:group {"layout":{"type":"constrained","contentSize":"740px"}} -->
-    <div class="wp-block-group"><!-- wp:template-part {"slug":"comments","theme":"lsx-design","area":"uncategorized"} /--></div>
+    <div class="wp-block-group"><!-- wp:template-part {"slug":"comments","area":"uncategorized"} /--></div>
     <!-- /wp:group -->
     
     <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|medium","right":"var:preset|spacing|x-small","bottom":"var:preset|spacing|medium","left":"var:preset|spacing|x-small"}}},"backgroundColor":"neutral","layout":{"type":"constrained","contentSize":"1200px"}} -->
@@ -68,4 +68,4 @@
     <!-- /wp:query --></div>
     <!-- /wp:group -->
     
-    <!-- wp:template-part {"slug":"footer","theme":"lsx-design","tagName":"footer","className":"site-footer"} /-->
+    <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->

--- a/templates/taxonomy-product_cat.html
+++ b/templates/taxonomy-product_cat.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"woo-header-light","theme":"lsx-design","align":"wide"} /-->
+<!-- wp:template-part {"slug":"woo-header-light","align":"wide"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0"},"padding":{"top":"40px","bottom":"80px"}}},"className":"site-content"} -->
 <main class="wp-block-group site-content" style="margin-top:0;padding-top:40px;padding-bottom:80px">
@@ -14,4 +14,4 @@
 </main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"lsx-design"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/woocommerce-blank.html
+++ b/templates/woocommerce-blank.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"woo-commerce-essential-header","theme":"lsx-design","align":"wide"} /-->
+<!-- wp:template-part {"slug":"woo-commerce-essential-header","align":"wide"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0"},"padding":{"top":"40px","bottom":"80px"}}},"className":"site-content"} -->
 <main class="wp-block-group site-content" style="margin-top:0;padding-top:40px;padding-bottom:80px">

--- a/templates/woocommerce-page.html
+++ b/templates/woocommerce-page.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"woo-header-light","theme":"lsx-design","align":"wide"} /-->
+<!-- wp:template-part {"slug":"woo-header-light","align":"wide"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"0"},"padding":{"top":"40px","bottom":"80px"}}},"className":"site-content"} -->
 <main class="wp-block-group site-content" style="margin-top:0;padding-top:40px;padding-bottom:80px">
@@ -9,4 +9,4 @@
 <!-- wp:post-content {"layout":{"type":"constrained"}} /--></main>
 <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","theme":"lsx-design","tagName":"footer","className":"site-footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->


### PR DESCRIPTION
## Description
The "theme" attribute has been removed from the templates html files.

#Screenshots
I have tested with a child theme and lsx as the parent theme active.

This is the no title template showing the headers.
![Screenshot 2023-11-14 at 11 07 13](https://github.com/lightspeedwp/lsx-design/assets/1805603/91a1f205-309c-4845-9cd2-e04078edaa7d)

