### PR TITLE
1.2.0 - editor and frontend differences

### DIFF
--- a/assets/css/woocommerce.css
+++ b/assets/css/woocommerce.css
@@ -84,11 +84,8 @@
  .wc-block-components-form .wc-block-components-text-input input[type=email], .wc-block-components-form .wc-block-components-text-input input[type=number], .wc-block-components-form .wc-block-components-text-input input[type=tel], .wc-block-components-form .wc-block-components-text-input input[type=text], .wc-block-components-form .wc-block-components-text-input input[type=url], .wc-block-components-text-input input[type=email], .wc-block-components-text-input input[type=number], .wc-block-components-text-input input[type=tel], .wc-block-components-text-input input[type=text], .wc-block-components-text-input input[type=url], .wc-block-components-textarea, .wc-block-components-combobox .wc-block-components-combobox-control input.components-combobox-control__input, .wc-block-components-form .wc-block-components-combobox .wc-block-components-combobox-control input.components-combobox-control__input{
     border:2px solid #2B2D2F!important;
 }
- .wc-block-cart__submit-container .wc-block-cart__submit-button, .wc-block-checkout__actions_row .wc-block-components-checkout-place-order-button{
-    background-color: var(--wp--preset--color--cta)!important;
-    color:var(--wp--preset--color--base)!important;
-}
- .wc-block-components-radio-control__option{
+
+.wc-block-components-radio-control__option{
     padding: 0 0 0 1.9em!important;
 }
  .wc-block-components-radio-control .wc-block-components-radio-control__input{
@@ -381,9 +378,8 @@
  .wc-block-featured-product h2 {
      font-size: var(--wp--preset--font-size--large)!important;
 }
- .wc-block-cart__submit-container .wc-block-cart__submit-button:hover, .wc-block-checkout__actions_row .wc-block-components-checkout-place-order-button:hover {
-     background-color: var(--wp--preset--color--ctahover)!important;
-}
+
+
  .woocommerce form.checkout_coupon, .woocommerce form.login, .woocommerce form.register {
      border: 2px solid #d3ced2!important;
 }
@@ -544,27 +540,7 @@
     color:#000!important;
     font-weight: 500;
 }
-.is-medium table.wc-block-cart-items .wc-block-cart-items__row, .is-mobile table.wc-block-cart-items .wc-block-cart-items__row, .is-small table.wc-block-cart-items .wc-block-cart-items__row{
-    -ms-grid-columns: 100px 132px;
-    grid-template-columns: 100px 132px;
-}
-.wc-block-cart-item__product .wc-block-components-product-name{
-    font-size:20px!important; 
-    font-weight: 700;
-    color:#000!important;
-}
-.wc-block-cart-item__product .wc-block-components-product-name:hover{
-    color:var(--wp--preset--color--woo)!important;
-}
-.wc-block-cart-item__product .wc-block-components-formatted-money-amount{
-    font-weight: 700;
-}
-.wc-block-cart-items__row p{
-    padding-bottom:0!important;
-}
-.editor-styles-wrapper table.wc-block-cart-items .wc-block-cart-items__row .wc-block-components-product-metadata, table.wc-block-cart-items .wc-block-cart-items__row .wc-block-components-product-metadata{
-    margin-bottom: 0em!important;
-}
+
 .wc-block-components-quantity-selector .wc-block-components-quantity-selector__button{
     background-color: #EFEFEF!important;
 }
@@ -573,9 +549,7 @@
     width: 100px;
     margin-right: 20px;
 }
-.editor-styles-wrapper table.wc-block-cart-items .wc-block-cart-items__row .wc-block-cart-item__quantity .wc-block-cart-item__remove-link, table.wc-block-cart-items .wc-block-cart-items__row .wc-block-cart-item__quantity .wc-block-cart-item__remove-link{
-    color:#FF0000!important;
-}
+
 .woocommerce .woocommerce-info .button{
     background-color: var(--wp--preset--color--secondary);
     border-radius: 0;

--- a/assets/css/woocommerce/checkout-totals-block.css
+++ b/assets/css/woocommerce/checkout-totals-block.css
@@ -1,0 +1,40 @@
+.wc-block-cart__submit-button,
+.wc-block-checkout__actions_row .wc-block-components-checkout-place-order-button{
+    background-color: var(--wp--preset--color--cta)!important;
+    color:var(--wp--preset--color--base)!important;
+}
+
+.wc-block-cart__submit-container .wc-block-cart__submit-button:hover,
+.wc-block-checkout__actions_row .wc-block-components-checkout-place-order-button:hover {
+     background-color: var(--wp--preset--color--ctahover)!important;
+}
+
+.is-medium table.wc-block-cart-items .wc-block-cart-items__row,
+.is-mobile table.wc-block-cart-items .wc-block-cart-items__row,
+.is-small table.wc-block-cart-items .wc-block-cart-items__row{
+    -ms-grid-columns: 100px 132px;
+    grid-template-columns: 100px 132px;
+}
+.wc-block-cart-item__product .wc-block-components-product-name{
+    font-size:20px!important; 
+    font-weight: 700;
+    color:#000!important;
+}
+.wc-block-cart-item__product .wc-block-components-product-name:hover{
+    color:var(--wp--preset--color--woo)!important;
+}
+.wc-block-cart-item__product .wc-block-components-formatted-money-amount{
+    font-weight: 700;
+}
+.wc-block-cart-items__row p{
+    padding-bottom:0!important;
+}
+.editor-styles-wrapper table.wc-block-cart-items .wc-block-cart-items__row .wc-block-components-product-metadata,
+table.wc-block-cart-items .wc-block-cart-items__row .wc-block-components-product-metadata {
+    margin-bottom: 0em!important;
+}
+
+.editor-styles-wrapper table.wc-block-cart-items .wc-block-cart-items__row .wc-block-cart-item__quantity .wc-block-cart-item__remove-link,
+table.wc-block-cart-items .wc-block-cart-items__row .wc-block-cart-item__quantity .wc-block-cart-item__remove-link{
+    color:#FF0000!important;
+}

--- a/includes/classes/class-setup.php
+++ b/includes/classes/class-setup.php
@@ -31,8 +31,9 @@ class Setup {
 	 */
 	public function init() {
 		add_action( 'after_setup_theme', array( $this, 'theme_setup' ) );
+		add_action( 'admin_init', array( $this, 'woo_asset_files' ) );
 	}
-
+	
 	/**
 	 * Adds the old menu options back in for site transition
 	 *
@@ -42,5 +43,16 @@ class Setup {
 	 */
 	public function theme_setup() {
 		add_theme_support( 'menus' );
+	}
+
+	/**
+	 * Load the assets files for Yoast
+	 *
+	 * @return void
+	 */
+	public function woo_asset_files() {
+		if ( class_exists( 'woocommerce' ) ) {
+			wp_enqueue_style( 'lsxd-woo-css', get_template_directory_uri() . '/assets/css/woocommerce.css', array(), time() );
+		}
 	}
 }

--- a/includes/classes/woocommerce/class-assets.php
+++ b/includes/classes/woocommerce/class-assets.php
@@ -54,6 +54,15 @@ class Assets {
 				'src'    => get_template_directory_uri() . '/assets/css/woocommerce/product-on-sale.css',
 				'path'   => get_template_directory() . '/assets/css/woocommerce/product-on-sale.css',
 			),
+			'woocommerce/checkout-totals-block' => array(
+				'handle' => 'lsxd-wc-checkout-totals-block',
+				'src'    => get_template_directory_uri() . '/assets/css/woocommerce/checkout-totals-block.css',
+				'path'   => get_template_directory() . '/assets/css/woocommerce/checkout-totals-block.css',
+			),
+
+			 
+
+
 		);
 		return $this->assets;
 	}


### PR DESCRIPTION
### Description
Some of the pages like the cart and checkout display differently in the editor, than they do in the frontend.

### Problem
The woocommerce.css is not being included in the editor, so those styles are not being applied.

### Solution
Enqueue the woocommerce.css and start transforming the CSS into block specific 

### Screenshots
You can now see the editor styles affecting the buttons etc in the editor.

![Screenshot 2023-11-23 at 13 08 33](https://github.com/lightspeedwp/lsx-design/assets/1805603/b6a191d6-dea9-404a-9a9d-14939dae48b0)
