### PR TITLE
Theme.json update from 2 to 3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 
 ## [[1.4.0]](https://github.com/lightspeedwp/lsx-design/releases/tag/1.4.0)
 
-
+- theme.json schema updated to version - [#139](https://github.com/lightspeedwp/lsx-design/issues/139).
+- theme.json default font and spacing sizes have been disabled.
 
 ## [[1.3.1]](https://github.com/lightspeedwp/lsx-design/releases/tag/1.3.1)
 

--- a/theme.json
+++ b/theme.json
@@ -1,4 +1,6 @@
 {
+	"version": 3,
+	"$schema": "https://schemas.wp.org/wp/6.6/theme.json",
 	"customTemplates": [
 		{
 			"name": "blank",
@@ -31,9 +33,6 @@
 	],
 	"settings": {
 		"appearanceTools": true,
-		"shadow": {
-			"defaultPresets": true
-		},
 		"blocks": {
 			"core/button": {
 				"spacing": {
@@ -637,6 +636,7 @@
 			]
 		},
 		"spacing": {
+			"defaultSpacingSizes":false,
 			"spacingSizes": [
 				{
 					"name": "xSmall",
@@ -676,6 +676,7 @@
 		"typography": {
 			"dropCap": true,
 			"fluid": true,
+			"defaultFontSizes" :false,
 			"fontFamilies": [
 				{
 					"fontFace": [
@@ -1614,7 +1615,5 @@
 			"name": "footer",
 			"title": "Footer"
 		}
-	],
-	"version": 2,
-	"$schema": "https://schemas.wp.org/wp/6.5/theme.json"
+	]
 }


### PR DESCRIPTION
### Description
The theme.json schema was updated to version 3. And the default font and spacing sizes have been disabled.

### Screenshots
The default uses a really bad looking selector.

Default WP Sizing
![Screenshot 2024-07-17 at 13 17 14](https://github.com/user-attachments/assets/e4d912c1-78ab-4979-9cef-d3bea7a783ab)

Custom Sizing values
![Screenshot 2024-07-17 at 13 17 24](https://github.com/user-attachments/assets/00a58ebe-8f49-46dd-8cfb-12d41083f6dc)

