### PR TITLE
All buttons to have underline

### DIFF
--- a/assets/css/blocks/loginout.css
+++ b/assets/css/blocks/loginout.css
@@ -39,7 +39,9 @@ form#loginform input.button-primary{
 }
 
 form#loginform input.button-primary:hover{
-    background-color: var(--wp--custom--colour--primary--600);}
+    background-color: var(--wp--custom--colour--primary--600);
+	text-decoration: underline;
+}
 
 
     .is-style-compressed form#loginform p.login-remember{display:inline-flex;width:30%;}

--- a/assets/css/blocks/navigation.css
+++ b/assets/css/blocks/navigation.css
@@ -1,6 +1,7 @@
 /* BLOCK LINKS */
-.wp-block-navigation .wp-block-navigation-item:hover > a.wp-block-navigation-item__content, .wp-block-navigation .wp-block-navigation-item.current-menu-item > a.wp-block-navigation-item__content{
-text-decoration: underline;
+.wp-block-navigation .wp-block-navigation-item:hover > a.wp-block-navigation-item__content,
+.wp-block-navigation .wp-block-navigation-item.current-menu-item > a.wp-block-navigation-item__content {
+	text-decoration: underline;
     text-decoration-thickness: 2px;
     text-underline-offset: 4px;
 }
@@ -25,4 +26,9 @@ body .wp-block-navigation a.wp-block-navigation-item__content {
 
 body .wp-block-navigation a.wp-block-navigation-item__content:active {
 	text-decoration-line: underline;
+}
+
+.wp-block-navigation .wp-element-button.wp-block-button__link:hover,
+.wp-block-navigation .wp-element-button.wp-block-button__link:hover {
+	text-decoration: underline;
 }

--- a/assets/css/woocommerce.css
+++ b/assets/css/woocommerce.css
@@ -1,4 +1,7 @@
 /* Woocommerce bug fixes ---------------------------------------------------------------------------- */
+:root :where(.wp-element-button, .wp-block-button__link):hover {
+	text-decoration: underline;
+}
 .wc-block-components-product-image p{
     padding:0!important;
     margin:0!important;

--- a/style.css
+++ b/style.css
@@ -104,7 +104,10 @@ body .is-layout-constrained > .wp-block-group.alignfull {
     border: 1px solid var(--wp--preset--color--contrast)!important;
 }
 /* Button --------------------------------------------- */
-
+input[type="button"]:hover,
+input[type="submit"]:hover {
+	text-decoration: underline;
+}
 
 /* Calendar --------------------------------------------- */
  .wp-block-calendar table caption, .wp-block-calendar table tbody {
@@ -190,7 +193,9 @@ body .is-layout-constrained > .wp-block-group.alignfull {
      padding: 2px;
 }
 
-.wp-block-navigation:not([style*=text-decoration]) a, .wp-block-navigation:not([style*=text-decoration]) a:focus, .wp-block-navigation:not([style*=text-decoration]) a:hover {
+.wp-block-navigation:not([style*=text-decoration]) a,
+.wp-block-navigation:not([style*=text-decoration]) a:focus,
+.wp-block-navigation:not([style*=text-decoration]) a:hover {
      text-decoration: none;
 }
 

--- a/style.css
+++ b/style.css
@@ -104,7 +104,8 @@ body .is-layout-constrained > .wp-block-group.alignfull {
     border: 1px solid var(--wp--preset--color--contrast)!important;
 }
 /* Button --------------------------------------------- */
- input[type="button"], input[type="submit"], .wp-block-post-comments input[type=submit]
+
+
 /* Calendar --------------------------------------------- */
  .wp-block-calendar table caption, .wp-block-calendar table tbody {
      color: var(--wp--preset--color--contrast);


### PR DESCRIPTION
### Description
- All buttons, including buttons from WooCommerce need to display a text under line when hovering.

### Solution
- We have added in CSS to the various specific block files to handle the hover.

### Resources.
- All buttons were checked on the LSX D Staging site. - [https://demo.lsx.design/](https://demo.lsx.design/)